### PR TITLE
Surface top unsettled accumulator pairs

### DIFF
--- a/app.js
+++ b/app.js
@@ -12,13 +12,156 @@ const pillEvents = document.getElementById('pillEvents');
 const pillExposure = document.getElementById('pillExposure');
 const diagEl    = document.getElementById('diag');
 const spinner   = document.getElementById('spinner');
+const comboSelects = [
+  document.getElementById('comboSelect1'),
+  document.getElementById('comboSelect2'),
+  document.getElementById('comboSelect3')
+];
+const comboCountEl   = document.getElementById('comboCount');
+const comboStakeEl   = document.getElementById('comboStake');
+const comboMessageEl = document.getElementById('comboMessage');
+const topPairsBody   = document.querySelector('#topPairsTable tbody');
+const topPairsEmpty  = document.getElementById('topPairsEmpty');
 
 let rawEvents = [];
 let aggRows   = [];
+let rawSlips  = [];
+let comboTimer = null;
+let hasParsedData = false;
+let topPairs = [];
 
 function setStatus(msg){ statusEl.textContent = msg || ''; }
 function escapeHtml(s){ return (s||'').replace(/[&<>"']/g, m => ({'&':'&amp;','<':'&lt;','>':'&gt;','"':'&quot;',"'":'&#39;'}[m])); }
 function fmtPKR(n){ return new Intl.NumberFormat('en-PK',{style:'currency',currency:'PKR',maximumFractionDigits:2}).format(n); }
+
+function mapSlips(slips){
+  return (slips || []).map((slip, idx) => {
+    const stake = Number(slip && slip.stakePKR) || 0;
+    const rawList = slip && Array.isArray(slip.events) ? slip.events.filter(Boolean) : [];
+    const events = Array.from(new Set(rawList));
+    const slipId = slip && slip.slipId ? String(slip.slipId) : `slip-${idx+1}`;
+    return { slipId, stakePKR: stake, events, eventSet: new Set(events) };
+  });
+}
+
+function buildPairStats(slips){
+  const pairMap = new Map();
+  (slips || []).forEach(slip => {
+    if (!slip || !Array.isArray(slip.events)) return;
+    const events = slip.events.filter(Boolean);
+    if (events.length < 2) return;
+    const sorted = Array.from(new Set(events)).sort((a,b)=> a.localeCompare(b));
+    for (let i=0; i<sorted.length-1; i++){
+      for (let j=i+1; j<sorted.length; j++){
+        const a = sorted[i];
+        const b = sorted[j];
+        const key = `${a}|||${b}`;
+        const entry = pairMap.get(key) || { events: [a,b], count: 0, totalStake: 0 };
+        entry.count += 1;
+        entry.totalStake += Number(slip.stakePKR) || 0;
+        pairMap.set(key, entry);
+      }
+    }
+  });
+
+  return Array.from(pairMap.values())
+    .sort((a,b)=>{
+      if (b.count !== a.count) return b.count - a.count;
+      if (b.totalStake !== a.totalStake) return b.totalStake - a.totalStake;
+      const nameA = `${a.events[0]}|||${a.events[1]}`;
+      const nameB = `${b.events[0]}|||${b.events[1]}`;
+      return nameA.localeCompare(nameB);
+    })
+    .slice(0,5);
+}
+
+function uniqueEventsList(){
+  return Array.from(new Set(rawEvents.map(r => r.eventKey))).sort((a,b)=> a.localeCompare(b));
+}
+
+function scheduleComboRecalc(){
+  if (comboTimer) clearTimeout(comboTimer);
+  comboTimer = setTimeout(runComboCalculation, 220);
+}
+
+function runComboCalculation(){
+  comboTimer = null;
+  const selections = comboSelects.map(sel => sel ? sel.value : '').filter(Boolean);
+  const uniqueSelections = Array.from(new Set(selections));
+
+  if (!rawEvents.length){
+    comboCountEl.textContent = '—';
+    comboStakeEl.textContent = '—';
+    comboMessageEl.textContent = hasParsedData ? 'No unsettled accumulators available.' : 'Import slips to get started.';
+    return;
+  }
+
+  if (selections.length < 2){
+    comboCountEl.textContent = '—';
+    comboStakeEl.textContent = '—';
+    comboMessageEl.textContent = 'Select at least two events to calculate overlap.';
+    return;
+  }
+
+  if (uniqueSelections.length !== selections.length){
+    comboCountEl.textContent = '—';
+    comboStakeEl.textContent = '—';
+    comboMessageEl.textContent = 'Choose distinct events to compare overlap.';
+    return;
+  }
+
+  if (!rawSlips.length){
+    comboCountEl.textContent = '0';
+    comboStakeEl.textContent = fmtPKR(0);
+    comboMessageEl.textContent = 'No unsettled accumulators available.';
+    return;
+  }
+
+  const matches = rawSlips.filter(slip => uniqueSelections.every(ev => slip.eventSet.has(ev)));
+  const count = matches.length;
+  const total = matches.reduce((sum, slip) => sum + (slip.stakePKR || 0), 0);
+
+  comboCountEl.textContent = String(count);
+  comboStakeEl.textContent = fmtPKR(total);
+  if (count){
+    comboMessageEl.textContent = `Found ${count} unsettled accumulator${count === 1 ? '' : 's'} with every selected event.`;
+  } else {
+    comboMessageEl.textContent = 'No unsettled accumulators contain every selected event.';
+  }
+}
+
+function updateComboSelectors(){
+  const events = uniqueEventsList();
+  const previous = comboSelects.map(sel => sel.value);
+
+  comboSelects.forEach((sel, idx) => {
+    if (!sel) return;
+    const docFrag = document.createDocumentFragment();
+    const placeholder = document.createElement('option');
+    placeholder.value = '';
+    placeholder.textContent = 'Select event…';
+    docFrag.appendChild(placeholder);
+
+    events.forEach(event => {
+      const opt = document.createElement('option');
+      opt.value = event;
+      opt.textContent = event;
+      docFrag.appendChild(opt);
+    });
+
+    sel.innerHTML = '';
+    sel.appendChild(docFrag);
+    const prev = previous[idx];
+    if (prev && events.includes(prev)){
+      sel.value = prev;
+    } else {
+      sel.value = '';
+    }
+    sel.disabled = events.length === 0;
+  });
+
+  scheduleComboRecalc();
+}
 
 function renderAggregates() {
   const map = new Map();
@@ -48,18 +191,50 @@ function renderAggregates() {
   pillExposure.textContent = `Total ${fmtPKR(totalStake)}`;
 }
 
+function renderTopPairs(){
+  if (!topPairsBody || !topPairsEmpty) return;
+  if (!topPairs.length){
+    topPairsBody.innerHTML = '';
+    topPairsEmpty.textContent = hasParsedData
+      ? 'No qualifying two-leg accumulator pairs found yet.'
+      : 'Import slips to surface the top accumulator pairs.';
+    topPairsEmpty.classList.remove('hidden');
+    return;
+  }
+
+  const rows = topPairs.map((pair, idx)=>`
+    <tr>
+      <td>${idx+1}</td>
+      <td>${escapeHtml(pair.events[0])}</td>
+      <td>${escapeHtml(pair.events[1])}</td>
+      <td class="num">${pair.count}</td>
+      <td class="num">${fmtPKR(pair.totalStake)}</td>
+    </tr>
+  `).join('');
+
+  topPairsBody.innerHTML = rows;
+  topPairsEmpty.classList.add('hidden');
+}
+
 async function parseAndRender(htmlText){
   spinner.classList.remove('hidden');
   setStatus('Parsing…');
   try{
-    const { rows, diagnostics } = window.parseHTMLToEvents(htmlText);
+    const { rows, slips, diagnostics } = window.parseHTMLToEvents(htmlText);
     diagEl.textContent = diagnostics || '';
     rawEvents = rows || [];
+    rawSlips = mapSlips(slips);
+    topPairs = buildPairStats(rawSlips);
+    hasParsedData = true;
     renderAggregates();
+    updateComboSelectors();
+    renderTopPairs();
     setStatus('Done');
   }catch(err){
     setStatus('Parse error');
     diagEl.textContent = String(err && err.message || err);
+    topPairs = [];
+    renderTopPairs();
   } finally {
     spinner.classList.add('hidden');
   }
@@ -90,7 +265,17 @@ document.querySelectorAll('#resultsTable th').forEach(th => {
 searchBox.addEventListener('input', renderAggregates);
 clearBtn.addEventListener('click', ()=>{ searchBox.value=''; renderAggregates(); });
 resetBtn.addEventListener('click', ()=>{
-  rawEvents = []; aggRows=[]; tableBody.innerHTML='';
+  rawEvents = []; aggRows=[]; rawSlips=[]; topPairs=[]; tableBody.innerHTML='';
   pillEvents.textContent='—'; pillExposure.textContent='—';
   diagEl.textContent=''; setStatus(''); fileInput.value='';
+  hasParsedData = false;
+  updateComboSelectors();
+  renderTopPairs();
 });
+
+comboSelects.forEach(sel => {
+  if (!sel) return;
+  sel.addEventListener('change', scheduleComboRecalc);
+});
+
+renderTopPairs();

--- a/index.html
+++ b/index.html
@@ -44,6 +44,7 @@
           <li>Counts <b>full parlay stake</b> for <b>each leg</b> of an unsettled parlay.</li>
           <li>Skips slips marked Lost/Won/Paid/Settled/Voided/Cashed out/Rejected.</li>
           <li>Skips legs marked Void/Refund/Returned/Cancelled.</li>
+          <li>The combined exposure card totals each qualifying accumulator stake once.</li>
         </ul>
       </section>
 
@@ -78,6 +79,70 @@
           </table>
           <div id="spinner" class="spinner hidden"></div>
         </div>
+      </section>
+
+      <section class="card">
+        <header class="card-head">
+          <h2>Top accumulator pairs (unsettled)</h2>
+          <p>Automatically surfaces the five most common two-leg combinations and their combined stakes.</p>
+        </header>
+
+        <div class="table-wrap top-pairs">
+          <table id="topPairsTable">
+            <thead>
+              <tr>
+                <th scope="col" class="num">#</th>
+                <th scope="col">Event A</th>
+                <th scope="col">Event B</th>
+                <th scope="col" class="num">Appearances</th>
+                <th scope="col" class="num">Combined stake</th>
+              </tr>
+            </thead>
+            <tbody></tbody>
+          </table>
+          <p id="topPairsEmpty" class="empty">Import slips to surface the top accumulator pairs.</p>
+        </div>
+      </section>
+
+      <section class="card">
+        <header class="card-head">
+          <h2>Combined exposure (unsettled accumulators)</h2>
+          <p>Select two or three events to see where they appear together. Stakes are counted once per qualifying slip.</p>
+        </header>
+
+        <div class="combo-grid">
+          <label class="combo-field">
+            <span>Event 1</span>
+            <select id="comboSelect1" disabled>
+              <option value="">Select event…</option>
+            </select>
+          </label>
+          <label class="combo-field">
+            <span>Event 2</span>
+            <select id="comboSelect2" disabled>
+              <option value="">Select event…</option>
+            </select>
+          </label>
+          <label class="combo-field">
+            <span>Event 3 (optional)</span>
+            <select id="comboSelect3" disabled>
+              <option value="">Select event…</option>
+            </select>
+          </label>
+        </div>
+
+        <div class="combo-meta">
+          <div class="combo-result">
+            <span class="combo-label">Matching accumulators</span>
+            <span class="combo-value" id="comboCount">—</span>
+          </div>
+          <div class="combo-result">
+            <span class="combo-label">Combined stake</span>
+            <span class="combo-value" id="comboStake">—</span>
+          </div>
+        </div>
+
+        <p class="combo-message" id="comboMessage">Import slips to get started.</p>
       </section>
 
       <section class="card card-compact">

--- a/service-worker.js
+++ b/service-worker.js
@@ -1,5 +1,12 @@
-const CACHE='bet-exposure-v7';
+const CACHE='bet-exposure-v8';
 const ASSETS=['./','./index.html','./styles.css','./app.js','./parser.js','./normalize.js','./manifest.json','./icons/icon-192.png','./icons/icon-512.png'];
 self.addEventListener('install',e=>{e.waitUntil(caches.open(CACHE).then(c=>c.addAll(ASSETS)).then(()=>self.skipWaiting()))});
-self.addEventListener('activate',e=>self.clients.claim());
+self.addEventListener('activate',e=>{
+  e.waitUntil(
+    caches.keys().then(keys=>Promise.all(
+      keys.filter(key=>key!==CACHE).map(key=>caches.delete(key))
+    ))
+  );
+  self.clients.claim();
+});
 self.addEventListener('fetch',e=>{const u=new URL(e.request.url);if(u.origin===location.origin){e.respondWith(caches.match(e.request).then(r=>r||fetch(e.request)))}});

--- a/styles.css
+++ b/styles.css
@@ -268,6 +268,86 @@ p {
   margin-bottom: 18px;
 }
 
+.combo-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(220px, 1fr));
+  gap: 16px;
+  margin-bottom: 22px;
+}
+
+.combo-field {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.combo-field span {
+  font-size: 14px;
+  font-weight: 600;
+  color: var(--muted);
+}
+
+.combo-field select {
+  padding: 12px 14px;
+  border-radius: 16px;
+  border: 1px solid var(--border-strong);
+  background: rgba(255, 255, 255, 0.92);
+  font-size: 15px;
+  transition: border-color 0.2s ease, box-shadow 0.2s ease;
+  font-family: inherit;
+  color: var(--text);
+}
+
+.combo-field select:focus {
+  outline: none;
+  border-color: rgba(79, 70, 239, 0.6);
+  box-shadow: 0 0 0 3px rgba(79, 70, 239, 0.18);
+}
+
+.combo-field select:disabled {
+  cursor: not-allowed;
+  opacity: 0.6;
+}
+
+.combo-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 16px;
+  margin-bottom: 14px;
+}
+
+.combo-result {
+  flex: 1 1 220px;
+  padding: 14px 18px;
+  border-radius: 18px;
+  border: 1px solid var(--border-strong);
+  background: rgba(255, 255, 255, 0.94);
+  box-shadow: inset 0 1px 2px rgba(15, 23, 42, 0.06);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.combo-label {
+  font-size: 13px;
+  color: var(--muted);
+  font-weight: 600;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+}
+
+.combo-value {
+  font-size: 22px;
+  font-weight: 700;
+  color: var(--text);
+}
+
+.combo-message {
+  font-size: 14px;
+  color: var(--muted);
+  font-weight: 500;
+}
+
 #searchBox {
   flex: 1;
   min-width: 240px;
@@ -356,6 +436,21 @@ button {
   border: 1px solid var(--border);
   background: var(--card-strong);
   box-shadow: var(--shadow-soft);
+}
+
+.table-wrap.top-pairs {
+  max-height: none;
+}
+
+.table-wrap.top-pairs table {
+  min-width: 100%;
+}
+
+.table-wrap.top-pairs .empty {
+  margin: 18px;
+  text-align: center;
+  color: var(--muted);
+  font-weight: 500;
 }
 
 .table-wrap::-webkit-scrollbar {


### PR DESCRIPTION
## Summary
- compute two-leg accumulator pair statistics from the parsed unsettled slips and expose them for rendering
- add a dedicated UI card that lists the top five pairs with counts and combined stakes while preserving the manual overlap selectors
- style the new card and ensure reset/error flows clear the surfaced pair data
- bump the service worker cache version and clean up old caches so updated assets reach installed clients

## Testing
- Not run (not provided)

------
https://chatgpt.com/codex/tasks/task_e_68ca0e5e772c8327a05017cdef7d4a36